### PR TITLE
fix: Changing case of toml to lowercase for consistency

### DIFF
--- a/template/netlify.toml
+++ b/template/netlify.toml
@@ -1,4 +1,4 @@
 [build]
-  Command = "yarn build"
-  Functions = "lambda"
-  Publish = "dist"
+  command = "yarn build"
+  functions = "lambda"
+  publish = "dist"


### PR DESCRIPTION
This change ensures that toml build commands in the generator are lowercase. Addresses #5 