### PR TITLE
updated netlify-lambda version to 1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@vue/cli-service": "^3.0.1",
     "@vue/cli-test-utils": "^3.0.1",
     "jest": "^23.5.0",
-    "netlify-lambda": "1.0.0-babel-7-beta",
+    "netlify-lambda": "^1.4.3",
     "rimraf": "^2.6.2"
   }
 }


### PR DESCRIPTION
The underlaying version of netlify-lambda used is over a year old.

I updated to the latest stable and reasonably tested it out, seems to work fine.

The main reason for updating is that the old version does not support authorization from netlify identity.

The updated version reads in the authorization header and populates the user object inside clientContext.